### PR TITLE
Add explicit includes for ORUtils.hh

### DIFF
--- a/Decoders/ORCMOSDecoder.cc
+++ b/Decoders/ORCMOSDecoder.cc
@@ -1,4 +1,5 @@
 #include "ORCMOSDecoder.hh"
+#include "ORUtils.hh"
 
 #include <string>
 #include <sstream>

--- a/Decoders/ORFECVltDecoder.cc
+++ b/Decoders/ORFECVltDecoder.cc
@@ -1,4 +1,5 @@
 #include "ORFECVltDecoder.hh"
+#include "ORUtils.hh"
 
 #include <string>
 #include <iomanip>

--- a/Decoders/ORPMTBaseCurrentDecoder.cc
+++ b/Decoders/ORPMTBaseCurrentDecoder.cc
@@ -1,4 +1,5 @@
 #include "ORPMTBaseCurrentDecoder.hh"
+#include "ORUtils.hh"
 
 #include <string>
 #include <sstream>

--- a/Decoders/ORPMTDecoder.cc
+++ b/Decoders/ORPMTDecoder.cc
@@ -3,6 +3,7 @@
 #include "TROOT.h"
 #include "ORPMTDecoder.hh"
 #include "ORLogger.hh"
+#include "ORUtils.hh"
 #include <netinet/in.h>
 
 ORPMTDecoder::ORPMTDecoder() {

--- a/Decoders/ORXL3HVDecoder.cc
+++ b/Decoders/ORXL3HVDecoder.cc
@@ -1,4 +1,5 @@
 #include "ORXL3HVDecoder.hh"
+#include "ORUtils.hh"
 
 #include <string>
 #include <iomanip>

--- a/Decoders/ORXL3VltDecoder.cc
+++ b/Decoders/ORXL3VltDecoder.cc
@@ -1,4 +1,5 @@
 #include "ORXL3VltDecoder.hh"
+#include "ORUtils.hh"
 
 #include <string>
 #include <iomanip>

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ SOURCES = $(wildcard *.cc) $(wildcard Decoders/*.cc)
 HEADERS = $(SOURCES:.cc=.hh)
 OBJECTS = $(SOURCES:.cc=.o)
 
-CXXFLAGS = -O3 -W -Wall -fPIC -g -I./Decoders
+CXXFLAGS = -O3 -W -Wall -fPIC -g -I./Decoders $(CFLAGS)
 ORLIBS += -lzmq
 
 CLANG := $(shell which clang)

--- a/ORSNOPackedEventProcessor.cc
+++ b/ORSNOPackedEventProcessor.cc
@@ -3,6 +3,7 @@
 #include "ORSNOPackedEventProcessor.hh"
 #include "ORRunContext.hh"
 #include "ORLogger.hh"
+#include "ORUtils.hh"
 #include <iostream>
 
 using namespace std;


### PR DESCRIPTION
Fixes compilation errors on Yosemite, Apple LLVM 6.

Also allow a command-line CFLAGS, so that we can, e.g., pass our
own "-I/path/to/cppzmq" at compile time. This is just tacked
onto CXXFLAGS.
